### PR TITLE
Added support to all vim forms of modelines

### DIFF
--- a/src/modelines.ts
+++ b/src/modelines.ts
@@ -92,7 +92,7 @@ export class ModelineSearcher {
 	}
 
 	private getVimModelineOptions(searchLines:string[]): any {
-		let codeModelineRegex = /^.{0,8}vim:(.*)/;
+		let codeModelineRegex = /^.{0,8}(ex|[vV]im?):(.*)/;
 		let codeModelineOptsRegex = /(\w+)=([^:\s]+)|(\w+)/g;
 
 		let parseOption = (name:string, value:string):any => {
@@ -117,7 +117,7 @@ export class ModelineSearcher {
 		searchLines.forEach(line => {
 			let match = line.match(codeModelineRegex);
 			if (match) {
-				let opts = match[1];
+				let opts = match[2];
 				while (match = codeModelineOptsRegex.exec(opts))
 					extend(options, parseOption(match[1] || match[3], match[2]));
 			}


### PR DESCRIPTION
This PR is adding support to vim modelines using vi: Vim: and ex:, beside the one it was already in place (vim:)

According to [Vim doc](https://vimhelp.org/options.txt.html#modeline) there is two forms of modelines:
1. [text]{white}{vi:|vim:|ex:}[white]{options}
2. [text]{white}{vi:|vim:|Vim:|ex:}[white]se[t] {options}:[text]