### PR TITLE
add sshconfig to ssh_config mapping

### DIFF
--- a/src/modelines.ts
+++ b/src/modelines.ts
@@ -236,6 +236,8 @@ function translateLanguageName(lang: string|undefined): string {
 			return 'shellscript';
 		case 'makefile-gmake':
 			return 'makefile';
+		case 'sshconfig':
+			return 'ssh_config';
 		default:
 			return lang;
 	}


### PR DESCRIPTION
Add the language mapping for ssh_config (provided by `ms-vscode-remote.remote-ssh-edit`)

vim, vi, kate,...: `sshconfig`
vscode: `ssh_config`